### PR TITLE
Adds support for blocking out subnets from ipam

### DIFF
--- a/service_test.go
+++ b/service_test.go
@@ -309,3 +309,156 @@ func TestNewSubnetAndDeleteSubnet(t *testing.T) {
 		}
 	}
 }
+
+// TestNewWithAllocatedNetworks tests that the NewSubnet method works correctly
+// with the allocated networks configuration.
+func TestNewWithAllocatedNetworks(t *testing.T) {
+	tests := []struct {
+		network          string
+		allocatedSubnets []string
+		mask             int
+
+		expectedErrorHandler func(error) bool
+		expectedSubnet       string
+	}{
+		// Test that a nil allocated subnets slice does not affect subnet handout.
+		{
+			network:          "10.0.0.0/16",
+			allocatedSubnets: nil,
+			mask:             24,
+
+			expectedSubnet: "10.0.0.0/24",
+		},
+
+		// Test that an empty allocated subnets slice does not affect subnet handout.
+		{
+			network:          "10.0.0.0/16",
+			allocatedSubnets: []string{},
+			mask:             24,
+
+			expectedSubnet: "10.0.0.0/24",
+		},
+
+		// Test that an allocated subnet, with a mask greater than the network mask,
+		// blocks the start of the range, and that the next subnet starts after it.
+		{
+			network:          "10.0.0.0/16",
+			allocatedSubnets: []string{"10.0.0.0/17"},
+			mask:             24,
+
+			expectedSubnet: "10.0.128.0/24",
+		},
+
+		// Test that two allocated subnets, with masks greater than the network mask,
+		// block the start of the range, and the next subnet starts after them.
+		{
+			network:          "10.0.0.0/16",
+			allocatedSubnets: []string{"10.0.0.0/24", "10.0.1.0/24"},
+			mask:             24,
+
+			expectedSubnet: "10.0.2.0/24",
+		},
+
+		// Test that an allocated subnet, after the start of the range,
+		// does not block the start of the range.
+		{
+			network:          "10.0.0.0/16",
+			allocatedSubnets: []string{"10.0.1.0/24"},
+			mask:             24,
+
+			expectedSubnet: "10.0.0.0/24",
+		},
+
+		// Test that an error is returned when creating the IPAM service if
+		// the allocated subnet is too big.
+		{
+			network:          "10.0.0.0/24",
+			allocatedSubnets: []string{"10.0.0.0/23"},
+
+			expectedErrorHandler: IsInvalidConfig,
+		},
+
+		// Test that an error is returned when creating the IPAM service
+		// if any of the allocated subnets are too large.
+		{
+			network:          "10.0.0.0/16",
+			allocatedSubnets: []string{"10.0.0.0/24", "10.0.0.0/8"},
+
+			expectedErrorHandler: IsInvalidConfig,
+		},
+
+		// Test that an error is returned when creating the IPAM service
+		// if an allocated subnet does not belong to the network.
+		{
+			network:          "10.0.0.0/16",
+			allocatedSubnets: []string{"192.168.0.0/16"},
+
+			expectedErrorHandler: IsInvalidConfig,
+		},
+	}
+
+	for index, test := range tests {
+		logger := microloggertest.New()
+		storage, err := memory.New(memory.DefaultConfig())
+		if err != nil {
+			t.Fatalf("%v: error creating new storage: %v", index, err)
+		}
+
+		_, network, err := net.ParseCIDR(test.network)
+		if err != nil {
+			t.Fatalf("%v: error returned parsing network cidr: %v", index, err)
+		}
+
+		var allocatedSubnets []net.IPNet
+		if test.allocatedSubnets == nil {
+			allocatedSubnets = nil
+		} else {
+			for _, allocatedSubnet := range test.allocatedSubnets {
+				_, subnet, err := net.ParseCIDR(allocatedSubnet)
+				if err != nil {
+					t.Fatalf("%v: error returned parsing subnet cidr: %v", index, err)
+				}
+				allocatedSubnets = append(allocatedSubnets, *subnet)
+			}
+		}
+
+		config := DefaultConfig()
+		config.Logger = logger
+		config.Storage = storage
+
+		config.AllocatedSubnets = allocatedSubnets
+		config.Network = network
+
+		service, err := New(config)
+		if err != nil && test.expectedErrorHandler == nil {
+			t.Fatalf("%v: unexpected error returned creating ipam service: %v\n", index, err)
+		}
+		if err != nil && !test.expectedErrorHandler(err) {
+			t.Fatalf("%v: incorrect error returned creating ipam service: %v\n", index, err)
+		}
+		if err == nil && test.expectedErrorHandler != nil {
+			t.Fatalf("%v: expected error not returned creating ipam service\n", index)
+		}
+
+		if test.expectedSubnet != "" {
+			_, expectedSubnet, err := net.ParseCIDR(test.expectedSubnet)
+			if err != nil {
+				t.Fatalf("%v: error returned parsing expected subnet: %v", index, err)
+			}
+
+			returnedSubnet, err := service.NewSubnet(net.CIDRMask(test.mask, 32))
+			if err != nil {
+				t.Fatalf("%v: error returned creating new subnet: %v\n", index, err)
+			}
+
+			if !returnedSubnet.IP.Equal(expectedSubnet.IP) || !bytes.Equal(returnedSubnet.Mask, expectedSubnet.Mask) {
+				t.Fatalf(
+					"%v: returned subnet did not match expected.\nexpected: %v\nreturned: %v\n",
+					index,
+					*expectedSubnet,
+					returnedSubnet,
+				)
+			}
+		}
+	}
+}


### PR DESCRIPTION
We have had a situation where it would be useful to block out some IP ranges from ipam (in this case, so that a host cluster can use up a portion of the overall IP range).

This PR allows for the ipam service to be created, and have a set of ip nets configured. These ip nets are considered used, and any subnets handed out by the ipam service will not overlap with these allocated subnets.