### PR TITLE
Allow submission of reserved networks outside of internal storage

### DIFF
--- a/ipam.go
+++ b/ipam.go
@@ -219,6 +219,14 @@ func Half(network net.IPNet) (first, second net.IPNet, err error) {
 	return first, second, nil
 }
 
+// CanonicalizeSubnets iterates over subnets and returns deduplicated list of
+// networks that belong to networkRange.
+//
+// Example:
+//	  networkRange: 192.168.2.0/24
+//	  subnets: [172.168.2.0/25, 192.168.2.0/25, 192.168.3.128/25, 192.168.2.0/25, 192.168.2.128/25]
+//	  returned: [192.168.2.0/25, 192.168.2.128/25]
+//
 func CanonicalizeSubnets(networkRange net.IPNet, subnets []net.IPNet) []net.IPNet {
 	// Naive deduplication as net.IPNet cannot be used as key for map. This
 	// should be ok for current foreseeable future.

--- a/ipam.go
+++ b/ipam.go
@@ -220,12 +220,19 @@ func Half(network net.IPNet) (first, second net.IPNet, err error) {
 }
 
 // CanonicalizeSubnets iterates over subnets and returns deduplicated list of
-// networks that belong to networkRange.
+// networks that belong to networkRange. Subnets that overlap each other but
+// aren't exactly the same are not removed. Subnets are returned in the same
+// order as they appear in input.
 //
 // Example:
 //	  networkRange: 192.168.2.0/24
 //	  subnets: [172.168.2.0/25, 192.168.2.0/25, 192.168.3.128/25, 192.168.2.0/25, 192.168.2.128/25]
 //	  returned: [192.168.2.0/25, 192.168.2.128/25]
+//
+// Example 2:
+//	  networkRange: 10.0.0.0/8
+//	  subnets: [10.1.0.0/16, 10.1.0.0/24, 10.1.1.0/24]
+//	  returned: [10.1.0.0/16, 10.1.0.0/24, 10.1.1.0/24]
 //
 func CanonicalizeSubnets(networkRange net.IPNet, subnets []net.IPNet) []net.IPNet {
 	// Naive deduplication as net.IPNet cannot be used as key for map. This

--- a/ipam_test.go
+++ b/ipam_test.go
@@ -897,3 +897,176 @@ func ExampleHalf() {
 	// 10.4.128.0/17
 
 }
+
+func Test_CanonicalizeSubnets(t *testing.T) {
+	testCases := []struct {
+		name            string
+		network         net.IPNet
+		subnets         []net.IPNet
+		expectedSubnets []net.IPNet
+	}{
+		{
+			name:            "case 0: deduplicate empty list of subnets",
+			network:         mustParseCIDR("192.168.0.0/16"),
+			subnets:         []net.IPNet{},
+			expectedSubnets: []net.IPNet{},
+		},
+		{
+			name:    "case 1: deduplicate list of subnets with one element",
+			network: mustParseCIDR("192.168.0.0/16"),
+			subnets: []net.IPNet{
+				mustParseCIDR("192.168.2.0/24"),
+			},
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("192.168.2.0/24"),
+			},
+		},
+		{
+			name:    "case 2: deduplicate list of subnets with two non-overlapping elements",
+			network: mustParseCIDR("192.168.0.0/16"),
+			subnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+			},
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+			},
+		},
+		{
+			name:    "case 3: deduplicate list of subnets with two overlapping elements",
+			network: mustParseCIDR("192.168.0.0/16"),
+			subnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.1.0/24"),
+			},
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+			},
+		},
+		{
+			name:    "case 4: deduplicate list of subnets with four elements where two overlap",
+			network: mustParseCIDR("192.168.0.0/16"),
+			subnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+				mustParseCIDR("192.168.3.0/24"),
+			},
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+				mustParseCIDR("192.168.3.0/24"),
+			},
+		},
+		{
+			name:    "case 5: same as case 4 but with different order",
+			network: mustParseCIDR("192.168.0.0/16"),
+			subnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+				mustParseCIDR("192.168.3.0/24"),
+				mustParseCIDR("192.168.3.0/24"),
+			},
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+				mustParseCIDR("192.168.3.0/24"),
+			},
+		},
+		{
+			name:    "case 6: same as case 4 but with different order",
+			network: mustParseCIDR("192.168.0.0/16"),
+			subnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+				mustParseCIDR("192.168.3.0/24"),
+			},
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+				mustParseCIDR("192.168.3.0/24"),
+			},
+		},
+		{
+			name:    "case 7: same as case 4 but with different order",
+			network: mustParseCIDR("192.168.0.0/16"),
+			subnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+				mustParseCIDR("192.168.3.0/24"),
+				mustParseCIDR("192.168.1.0/24"),
+			},
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+				mustParseCIDR("192.168.3.0/24"),
+			},
+		},
+		{
+			name:    "case 7: deduplicate list of subnets with fiveelements where two overlap",
+			network: mustParseCIDR("192.168.0.0/16"),
+			subnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+				mustParseCIDR("192.168.3.0/24"),
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.4.0/24"),
+			},
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+				mustParseCIDR("192.168.3.0/24"),
+				mustParseCIDR("192.168.4.0/24"),
+			},
+		},
+		{
+			name:    "case 8: deduplicate list of subnets with duplicates and IPs from different segments",
+			network: mustParseCIDR("192.168.0.0/16"),
+			subnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+				mustParseCIDR("192.168.3.0/24"),
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.4.0/24"),
+				mustParseCIDR("172.31.0.1/16"),
+				mustParseCIDR("10.2.0.4/24"),
+			},
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("192.168.1.0/24"),
+				mustParseCIDR("192.168.2.0/24"),
+				mustParseCIDR("192.168.3.0/24"),
+				mustParseCIDR("192.168.4.0/24"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			subnets := CanonicalizeSubnets(tc.network, tc.subnets)
+
+			if !reflect.DeepEqual(subnets, tc.expectedSubnets) {
+				msg := "expected: {\n"
+				for _, n := range tc.expectedSubnets {
+					msg += fmt.Sprintf("\t%s,\n", n.String())
+				}
+				msg += "}\n\ngot: {\n"
+				for _, n := range subnets {
+					msg += fmt.Sprintf("\t%s,\n", n.String())
+				}
+				msg += "}"
+				t.Fatal(msg)
+			}
+		})
+	}
+}
+
+func mustParseCIDR(val string) net.IPNet {
+	_, n, err := net.ParseCIDR(val)
+	if err != nil {
+		panic(err)
+	}
+
+	return *n
+}

--- a/ipam_test.go
+++ b/ipam_test.go
@@ -1040,6 +1040,34 @@ func Test_CanonicalizeSubnets(t *testing.T) {
 				mustParseCIDR("192.168.4.0/24"),
 			},
 		},
+		{
+			name:    "case 9: ensure that smaller overlapping subnets are accepted",
+			network: mustParseCIDR("10.0.0.0/8"),
+			subnets: []net.IPNet{
+				mustParseCIDR("10.1.0.0/16"),
+				mustParseCIDR("10.1.0.0/24"),
+				mustParseCIDR("10.1.1.0/24"),
+			},
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("10.1.0.0/16"),
+				mustParseCIDR("10.1.0.0/24"),
+				mustParseCIDR("10.1.1.0/24"),
+			},
+		},
+		{
+			name:    "case 10: same as case 9 but with different input ordering",
+			network: mustParseCIDR("10.0.0.0/8"),
+			subnets: []net.IPNet{
+				mustParseCIDR("10.1.0.0/24"),
+				mustParseCIDR("10.1.1.0/24"),
+				mustParseCIDR("10.1.0.0/16"),
+			},
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("10.1.0.0/24"),
+				mustParseCIDR("10.1.1.0/24"),
+				mustParseCIDR("10.1.0.0/16"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/service.go
+++ b/service.go
@@ -2,6 +2,7 @@ package ipam
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
@@ -102,7 +103,7 @@ func (s *Service) listSubnets(ctx context.Context) ([]net.IPNet, error) {
 // CreateSubnet returns the next available subnet, of the configured size,
 // from the configured network.
 func (s *Service) CreateSubnet(ctx context.Context, mask net.IPMask, annotation string, reserved []net.IPNet) (net.IPNet, error) {
-	s.logger.LogCtx(ctx, "level", "info", "message", "creating new subnet")
+	s.logger.LogCtx(ctx, "level", "debug", "message", "creating subnet")
 	defer updateMetrics("create", time.Now())
 
 	existingSubnets, err := s.listSubnets(ctx)
@@ -114,13 +115,11 @@ func (s *Service) CreateSubnet(ctx context.Context, mask net.IPMask, annotation 
 	existingSubnets = append(existingSubnets, s.allocatedSubnets...)
 	existingSubnets = CanonicalizeSubnets(s.network, existingSubnets)
 
-	s.logger.LogCtx(ctx, "level", "info", "message", "computing next subnet")
 	subnet, err := Free(s.network, mask, existingSubnets)
 	if err != nil {
 		return net.IPNet{}, microerror.Mask(err)
 	}
 
-	s.logger.LogCtx(ctx, "level", "info", "message", "putting subnet", "subnet", subnet.String())
 	kv, err := microstorage.NewKV(encodeKey(subnet), annotation)
 	if err != nil {
 		return net.IPNet{}, microerror.Mask(err)
@@ -129,13 +128,15 @@ func (s *Service) CreateSubnet(ctx context.Context, mask net.IPMask, annotation 
 		return net.IPNet{}, microerror.Mask(err)
 	}
 
+	s.logger.LogCtx(ctx, "level", "debug", "message", "created subnet")
+
 	return subnet, nil
 }
 
 // DeleteSubnet deletes the given subnet from IPAM storage,
 // meaning it can be given out again.
 func (s *Service) DeleteSubnet(ctx context.Context, subnet net.IPNet) error {
-	s.logger.LogCtx(ctx, "level", "info", "message", "deleting subnet", "subnet", subnet.String())
+	s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting subnet %#q", subnet.String()))
 	defer updateMetrics("delete", time.Now())
 
 	k, err := microstorage.NewK(encodeKey(subnet))
@@ -145,6 +146,8 @@ func (s *Service) DeleteSubnet(ctx context.Context, subnet net.IPNet) error {
 	if err := s.storage.Delete(ctx, k); err != nil {
 		return microerror.Mask(err)
 	}
+
+	s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted subnet %#q", subnet.String()))
 
 	return nil
 }

--- a/service_example_test.go
+++ b/service_example_test.go
@@ -29,13 +29,13 @@ func Example() {
 
 	// Request a subnet. There are no subnets in the network currently,
 	// so this subnet will be at the start of the IP range.
-	firstNetwork, _ := service.CreateSubnet(ctx, net.CIDRMask(24, 32), "arbitrary value")
+	firstNetwork, _ := service.CreateSubnet(ctx, net.CIDRMask(24, 32), "arbitrary value", nil)
 	fmt.Println(firstNetwork.String())
 
 	// Request a second, smaller subnet.
 	// There is one subnet currently, so this subnet will begin after
 	// the previous subnet.
-	secondNetwork, _ := service.CreateSubnet(ctx, net.CIDRMask(32, 32), "")
+	secondNetwork, _ := service.CreateSubnet(ctx, net.CIDRMask(32, 32), "", nil)
 	fmt.Println(secondNetwork.String())
 
 	// Release the first subnet from the service.
@@ -46,13 +46,13 @@ func Example() {
 	// As the range at the start of the network is free,
 	// and this subnet fits in the space,
 	// it will be placed there.
-	thirdNetwork, _ := service.CreateSubnet(ctx, net.CIDRMask(25, 32), "")
+	thirdNetwork, _ := service.CreateSubnet(ctx, net.CIDRMask(25, 32), "", nil)
 	fmt.Println(thirdNetwork.String())
 
 	// Request a fourth subnet.
 	// As 2 /25s fit within a /24, both this subnet and the previous
 	// subnet fit in the space of the older /24.
-	fourthNetwork, _ := service.CreateSubnet(ctx, net.CIDRMask(25, 32), "")
+	fourthNetwork, _ := service.CreateSubnet(ctx, net.CIDRMask(25, 32), "", nil)
 	fmt.Println(fourthNetwork.String())
 
 	// Output:

--- a/service_test.go
+++ b/service_test.go
@@ -273,7 +273,7 @@ func TestNewSubnetAndDeleteSubnet(t *testing.T) {
 			if step.add {
 				mask := net.CIDRMask(step.mask, 32)
 
-				returnedSubnet, err := service.CreateSubnet(context.Background(), mask, fmt.Sprintf("test-%d", index))
+				returnedSubnet, err := service.CreateSubnet(context.Background(), mask, fmt.Sprintf("test-%d", index), nil)
 				if err != nil {
 					if step.expectedErrorHandler != nil {
 						if !step.expectedErrorHandler(err) {
@@ -450,7 +450,7 @@ func TestNewWithAllocatedNetworks(t *testing.T) {
 				t.Fatalf("%v: error returned parsing expected subnet: %v", index, err)
 			}
 
-			returnedSubnet, err := service.CreateSubnet(context.Background(), net.CIDRMask(test.mask, 32), fmt.Sprintf("test-%d", index))
+			returnedSubnet, err := service.CreateSubnet(context.Background(), net.CIDRMask(test.mask, 32), fmt.Sprintf("test-%d", index), nil)
 			if err != nil {
 				t.Fatalf("%v: error returned creating new subnet: %v\n", index, err)
 			}


### PR DESCRIPTION
IPAM Service maintains its allocations within its own storage, but there
are use cases when it's needed to be able to submit additional network
reservations from outside. One example is when migrating IPAM from one
component to another and changing storage while doing this.

In order to properly merge list of networks from different sources,
a function to canonicalize list of networks was added here.