### PR TITLE
move code from aws-operator to ipam package

### DIFF
--- a/error.go
+++ b/error.go
@@ -59,3 +59,12 @@ var invalidConfigError = microerror.New("invalid config")
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var invalidParameterError = &microerror.Error{
+	Kind: "invalid parameter",
+}
+
+// IsInvalidParameter asserts invalidParameterError.
+func IsInvalidParameter(err error) bool {
+	return microerror.Cause(err) == invalidParameterError
+}

--- a/ipam.go
+++ b/ipam.go
@@ -13,6 +13,23 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+// CalculateSubnetMask calculates new subnet mask to accommodate n subnets.
+func CalculateSubnetMask(networkMask net.IPMask, n uint) (net.IPMask, error) {
+	if n == 0 {
+		return nil, microerror.Maskf(invalidParameterError, "divide by zero")
+	}
+
+	// Calculate amount of bits needed to accommodate at least N subnets.
+	subnetBitsNeeded := bits.Len(n - 1)
+
+	maskOnes, maskBits := networkMask.Size()
+	if subnetBitsNeeded > maskBits-maskOnes {
+		return nil, microerror.Maskf(invalidParameterError, "no room in network mask %s to accommodate %d subnets", networkMask.String(), n)
+	}
+
+	return net.CIDRMask(maskOnes+subnetBitsNeeded, maskBits), nil
+}
+
 // CanonicalizeSubnets iterates over subnets and returns deduplicated list of
 // networks that belong to networkRange. Subnets that overlap each other but
 // aren't exactly the same are not removed. Subnets are returned in the same
@@ -140,6 +157,26 @@ func Half(network net.IPNet) (first, second net.IPNet, err error) {
 	}
 
 	return first, second, nil
+}
+
+// Split returns n subnets from network.
+func Split(network net.IPNet, n uint) ([]net.IPNet, error) {
+	mask, err := CalculateSubnetMask(network.Mask, n)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var subnets []net.IPNet
+	for i := uint(0); i < n; i++ {
+		subnet, err := Free(network, mask, subnets)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		subnets = append(subnets, subnet)
+	}
+
+	return subnets, nil
 }
 
 // add increments the given IP by the number.

--- a/ipam_test.go
+++ b/ipam_test.go
@@ -98,6 +98,94 @@ func TestAdd(t *testing.T) {
 	}
 }
 
+func Test_CalculateSubnetMask(t *testing.T) {
+	testCases := []struct {
+		name         string
+		mask         net.IPMask
+		n            uint
+		expectedMask net.IPMask
+		errorMatcher func(error) bool
+	}{
+		{
+			name:         "case 0: split /24 into one network",
+			mask:         net.CIDRMask(24, 32),
+			n:            1,
+			expectedMask: net.CIDRMask(24, 32),
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 1: split /24 into two networks",
+			mask:         net.CIDRMask(24, 32),
+			n:            2,
+			expectedMask: net.CIDRMask(25, 32),
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 2: split /24 into three networks",
+			mask:         net.CIDRMask(24, 32),
+			n:            3,
+			expectedMask: net.CIDRMask(26, 32),
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 3: split /24 into four networks",
+			mask:         net.CIDRMask(24, 32),
+			n:            4,
+			expectedMask: net.CIDRMask(26, 32),
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 4: split /24 into five networks",
+			mask:         net.CIDRMask(24, 32),
+			n:            5,
+			expectedMask: net.CIDRMask(27, 32),
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 5: split /22 into 7 networks",
+			mask:         net.CIDRMask(22, 32),
+			n:            7,
+			expectedMask: net.CIDRMask(25, 32),
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 6: split /31 into 8 networks (no room)",
+			mask:         net.CIDRMask(31, 32),
+			n:            7,
+			expectedMask: nil,
+			errorMatcher: IsInvalidParameter,
+		},
+		{
+			name:         "case 7: IPv6 masks (split /31 for seven networks)",
+			mask:         net.CIDRMask(31, 128),
+			n:            7,
+			expectedMask: net.CIDRMask(34, 128),
+			errorMatcher: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mask, err := CalculateSubnetMask(tc.mask, tc.n)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(mask, tc.expectedMask) {
+				t.Fatalf("Mask == %q, want %q", mask, tc.expectedMask)
+			}
+		})
+	}
+}
+
 func TestContains(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -1097,6 +1185,82 @@ func TestSpace(t *testing.T) {
 				)
 			}
 		}
+	}
+}
+
+func Test_Split(t *testing.T) {
+	testCases := []struct {
+		name            string
+		network         net.IPNet
+		n               uint
+		expectedSubnets []net.IPNet
+		errorMatcher    func(error) bool
+	}{
+		{
+			name:    "case 0: split /24 into four networks",
+			network: mustParseCIDR("192.168.8.0/24"),
+			n:       4,
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("192.168.8.0/26"),
+				mustParseCIDR("192.168.8.64/26"),
+				mustParseCIDR("192.168.8.128/26"),
+				mustParseCIDR("192.168.8.192/26"),
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:    "case 1: split /22 into 7 networks",
+			network: mustParseCIDR("10.100.0.0/22"),
+			n:       7,
+			expectedSubnets: []net.IPNet{
+				mustParseCIDR("10.100.0.0/25"),
+				mustParseCIDR("10.100.0.128/25"),
+				mustParseCIDR("10.100.1.0/25"),
+				mustParseCIDR("10.100.1.128/25"),
+				mustParseCIDR("10.100.2.0/25"),
+				mustParseCIDR("10.100.2.128/25"),
+				mustParseCIDR("10.100.3.0/25"),
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:            "case 2: split /31 into 8 networks (no room)",
+			network:         mustParseCIDR("192.168.8.128/31"),
+			n:               7,
+			expectedSubnets: nil,
+			errorMatcher:    IsInvalidParameter,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			subnets, err := Split(tc.network, tc.n)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(subnets, tc.expectedSubnets) {
+				msg := "expected: {\n"
+				for _, n := range tc.expectedSubnets {
+					msg += fmt.Sprintf("\t%s,\n", n.String())
+				}
+				msg += "}\n\ngot: {\n"
+				for _, n := range subnets {
+					msg += fmt.Sprintf("\t%s,\n", n.String())
+				}
+				msg += "}"
+				t.Fatal(msg)
+
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Towards Node Pools. While working on the `ipam` resource refactoring in the `aws-operator` I got weird import cycles. The package design was a bit off and I thought it makes sense to move some methods from the network management in the aws-operator to here. This then also solves the import cycle I faced. 