### PR TITLE
Cidr overlap filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
 
+- Instead of returning an error, ignore allocatedSubnets that are outside of the network range.
 
 ## [0.2.0] 2020-03-24
 

--- a/service_test.go
+++ b/service_test.go
@@ -371,33 +371,6 @@ func TestNewWithAllocatedNetworks(t *testing.T) {
 
 			expectedSubnet: "10.0.0.0/24",
 		},
-
-		// Test that an error is returned when creating the IPAM service if
-		// the allocated subnet is too big.
-		{
-			network:          "10.0.0.0/24",
-			allocatedSubnets: []string{"10.0.0.0/23"},
-
-			expectedErrorHandler: IsInvalidConfig,
-		},
-
-		// Test that an error is returned when creating the IPAM service
-		// if any of the allocated subnets are too large.
-		{
-			network:          "10.0.0.0/16",
-			allocatedSubnets: []string{"10.0.0.0/24", "10.0.0.0/8"},
-
-			expectedErrorHandler: IsInvalidConfig,
-		},
-
-		// Test that an error is returned when creating the IPAM service
-		// if an allocated subnet does not belong to the network.
-		{
-			network:          "10.0.0.0/16",
-			allocatedSubnets: []string{"192.168.0.0/16"},
-
-			expectedErrorHandler: IsInvalidConfig,
-		},
 	}
 
 	for index, test := range tests {


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.

This PR allows passing non overlapping CIDRs as allocatedSubnets without causing a runtime error.
This is needed in case we want to have Control Planes in a non overlapping subnet with the tenant clusters.